### PR TITLE
Add pretty response handling

### DIFF
--- a/command.go
+++ b/command.go
@@ -485,11 +485,11 @@ func (cmd *Cmd) readReply(rd *proto.Reader) (err error) {
 
 func (cmd *Cmd) PrettyRender() {
 	if cmd.Err() != nil && !errors.Is(cmd.Err(), Nil) {
-		_, cmd.err = proto.RenderOutput(cmd.Name(), nil, cmd.Err())
+		_, cmd.err = proto.RenderOutput(cmd.Name(), cmd.Args(), nil, cmd.Err())
 		return
 	}
 
-	cmd.val, _ = proto.RenderOutput(cmd.Name(), cmd.Val(), nil)
+	cmd.val, _ = proto.RenderOutput(cmd.Name(), cmd.Args(), cmd.Val(), nil)
 }
 
 //------------------------------------------------------------------------------

--- a/command.go
+++ b/command.go
@@ -3,6 +3,7 @@ package dicedb
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -480,6 +481,15 @@ func (cmd *Cmd) BoolSlice() ([]bool, error) {
 func (cmd *Cmd) readReply(rd *proto.Reader) (err error) {
 	cmd.val, err = rd.ReadReply()
 	return err
+}
+
+func (cmd *Cmd) PrettyRender() {
+	if cmd.Err() != nil && !errors.Is(cmd.Err(), Nil) {
+		_, cmd.err = proto.RenderOutput(cmd.Name(), nil, cmd.Err())
+		return
+	}
+
+	cmd.val, _ = proto.RenderOutput(cmd.Name(), cmd.Val(), nil)
 }
 
 //------------------------------------------------------------------------------

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -1,6 +1,8 @@
 module github.com/redis/go-redis/example/hll
 
-go 1.18
+go 1.23
+
+toolchain go1.23.0
 
 replace github.com/dicedb/dicedb-go => ../..
 

--- a/example/hll/go.sum
+++ b/example/hll/go.sum
@@ -4,3 +4,4 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dicedb/go-dice v0.0.0-20240820180649-d97f15fca831/go.mod h1:8+VZrr14c2LW8fW4tWZ8Bv3P2lfvlg+PpsSn5cWWuiQ=

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -1,6 +1,8 @@
 module github.com/redis/go-redis/example/lua-scripting
 
-go 1.18
+go 1.23
+
+toolchain go1.23.0
 
 replace github.com/dicedb/dicedb-go => ../..
 

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -1,6 +1,8 @@
 module github.com/redis/go-redis/example/redis-bloom
 
-go 1.18
+go 1.23
+
+toolchain go1.23.0
 
 replace github.com/dicedb/dicedb-go => ../..
 

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -1,6 +1,8 @@
 module github.com/redis/go-redis/extra/rediscmd/v9
 
-go 1.19
+go 1.23
+
+toolchain go1.23.0
 
 replace github.com/dicedb/dicedb-go => ../..
 

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -1,6 +1,8 @@
 module github.com/redis/go-redis/extra/redisotel/v9
 
-go 1.19
+go 1.23
+
+toolchain go1.23.0
 
 replace github.com/dicedb/dicedb-go => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dicedb/dicedb-go
 
-go 1.18
+go 1.23
 
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0

--- a/internal/proto/renderer.go
+++ b/internal/proto/renderer.go
@@ -1,0 +1,289 @@
+package proto
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var respNil = "(nil)"
+var emptyList = "(empty list or set)"
+var invalidString = "(error) invalid type"
+
+// Define command groups as `map[string]struct{}` for efficient lookups
+var simpleStringCommands = map[string]struct{}{
+	"AUTH":    {},
+	"SELECT":  {},
+	"RENAME":  {},
+	"RESTORE": {},
+	"MSET":    {},
+	"SET":     {},
+	"PFMERGE": {},
+	"FLUSHDB": {},
+}
+
+var intCommands = map[string]struct{}{
+	"COPY":         {},
+	"DEL":          {},
+	"EXISTS":       {},
+	"EXPIRE":       {},
+	"EXPIREAT":     {},
+	"EXPIRETIME":   {},
+	"PERSIST":      {},
+	"PTTL":         {},
+	"TTL":          {},
+	"TOUCH":        {},
+	"HDEL":         {},
+	"HEXISTS":      {},
+	"HINCRBY":      {},
+	"HSET":         {},
+	"HSETNX":       {},
+	"HSTRLEN":      {},
+	"PFADD":        {},
+	"PFCOUNT":      {},
+	"LPUSH":        {},
+	"RPUSH":        {},
+	"LLEN":         {},
+	"SADD":         {},
+	"SREM":         {},
+	"SCARD":        {},
+	"SETBIT":       {},
+	"SETNX":        {},
+	"INCR":         {},
+	"INCRBY":       {},
+	"DECR":         {},
+	"DECRBY":       {},
+	"APPEND":       {},
+	"ZADD":         {},
+	"HINCRBYFLOAT": {},
+	"BITPOS":       {},
+}
+
+var bulkStringCommands = map[string]struct{}{
+	"ECHO":         {},
+	"PING":         {},
+	"DUMP":         {},
+	"TYPE":         {},
+	"GEODIST":      {},
+	"HGET":         {},
+	"HINCRBYFLOAT": {},
+	"GET":          {},
+	"GETEX":        {},
+	"GETDEL":       {},
+	"GETRANGE":     {},
+	"GETSET":       {},
+	"INCRBYFLOAT":  {},
+	"ZSCORE":       {},
+}
+
+var listCommands = map[string]struct{}{
+	"HELLO":      {},
+	"KEYS":       {},
+	"HKEYS":      {},
+	"HMGET":      {},
+	"HVALS":      {},
+	"HRANDFIELD": {},
+	"SMEMBERS":   {},
+	"SDIFF":      {},
+	"SINTER":     {},
+	"MGET":       {},
+	"BITFIELD":   {},
+	"COMMAND":    {},
+}
+
+func RenderOutput(cmdName string, cmdVal interface{}, cmdErr error) (interface{}, error) {
+	fn := getRender(cmdName)
+	if cmdErr != nil {
+		return nil, renderError(cmdErr)
+	}
+
+	// If we don't have a renderer defined leave it as it is
+	if fn == nil {
+		return cmdVal, nil
+	}
+
+	return fn(cmdVal), nil
+}
+
+// getRender retrieves the appropriate callback for the command
+func getRender(commandName string) func(value interface{}) interface{} {
+	commandUpper := strings.ToUpper(strings.TrimSpace(commandName))
+
+	// Determine the render method based on command group
+	if _, exists := simpleStringCommands[commandUpper]; exists {
+		return renderSimpleString
+	}
+	if _, exists := intCommands[commandUpper]; exists {
+		return renderInt
+	}
+	if _, exists := bulkStringCommands[commandUpper]; exists {
+		return renderBulkString
+	}
+	if _, exists := listCommands[commandUpper]; exists {
+		return renderList
+	}
+
+	return nil
+}
+
+func ensureStr(input interface{}) string {
+	switch v := input.(type) {
+	case string:
+		return v
+	case error:
+		return v.Error()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func renderError(errorMsg error) error {
+	err := ensureStr(errorMsg)
+
+	return fmt.Errorf("(error) %s", err)
+}
+
+// Render functions
+func renderBulkString(value interface{}) interface{} {
+	if value == nil {
+		return respNil
+	}
+
+	result, ok := value.(int64)
+	if ok {
+		return renderInt(result)
+	}
+
+	return fmt.Sprintf("%v", value)
+}
+
+func renderInt(value interface{}) interface{} {
+	if value == nil {
+		return respNil
+	}
+
+	if intValue, ok := value.(int64); ok {
+		return fmt.Sprintf("(integer) %d", intValue)
+	}
+
+	return invalidString
+}
+
+func renderList(value interface{}) interface{} {
+	items, ok := value.([]interface{})
+	if !ok {
+		return invalidString
+	}
+
+	var builder strings.Builder
+	for i, item := range items {
+		// Convert item to string
+		if item == nil {
+			builder.WriteString(fmt.Sprintf("%d) %v\n", i+1, respNil))
+			continue
+		}
+
+		strItem := fmt.Sprintf("%v", item)
+
+		// Check if the string is already quoted, if not, add quotes
+		if !(strings.HasPrefix(strItem, "\"") && strings.HasSuffix(strItem, "\"")) {
+			strItem = fmt.Sprintf("\"%s\"", strItem)
+		}
+
+		builder.WriteString(fmt.Sprintf("%d) %s\n", i+1, strItem))
+	}
+	return builder.String()
+}
+
+func renderListOrString(value interface{}) interface{} {
+	if items, ok := value.([]interface{}); ok {
+		return renderList(items)
+	}
+	return renderBulkString(value)
+}
+
+func renderStringOrInt(value interface{}) interface{} {
+	if intValue, ok := value.(int); ok {
+		return renderInt(intValue)
+	}
+	return renderBulkString(value)
+}
+
+func renderSimpleString(value interface{}) interface{} {
+	if value == nil {
+		return respNil
+	}
+
+	text := fmt.Sprintf("%v", value)
+	return text
+}
+
+func renderHashPairs(value interface{}) interface{} {
+	items, ok := value.([]interface{})
+	if len(items) == 0 {
+		return emptyList
+	}
+	if !ok || len(items)%2 != 0 {
+		return "(error) invalid hash pair format"
+	}
+
+	var builder strings.Builder
+	indexWidth := len(strconv.Itoa(len(items) / 2))
+	for i := 0; i < len(items); i += 2 {
+		key := fmt.Sprintf("%v", items[i])
+		value := fmt.Sprintf("%v", items[i+1])
+
+		// Format the index and key
+		indexStr := fmt.Sprintf("%*d) ", indexWidth, i/2+1)
+		builder.WriteString(indexStr)
+		builder.WriteString(key + "\n")
+
+		// Format the value, ensuring correct indentation
+		// and preserving quotes if necessary
+		if strings.Contains(value, "\"") {
+			value = fmt.Sprintf("%q", value)
+		}
+		valueStr := strings.Repeat(" ", len(indexStr)) + value
+		builder.WriteString(valueStr + "\n")
+	}
+	return builder.String()
+}
+
+func commandHscan(value interface{}) interface{} {
+	scanResult, ok := value.([]interface{})
+	if !ok || len(scanResult) < 2 {
+		return "(error) invalid type or format"
+	}
+
+	cursor := fmt.Sprintf("%v", scanResult[0])
+	items, ok := scanResult[1].([]interface{})
+	if !ok {
+		return "(error) invalid scan items format"
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("(cursor) %s\n", cursor))
+	renderedItems := renderHashPairs(items)
+	builder.WriteString(fmt.Sprintf("%s", renderedItems))
+
+	return builder.String()
+}
+
+// RenderMembers renders a list of set or sorted set members
+func renderMembers(value interface{}) interface{} {
+	items, ok := value.([]interface{})
+	if !ok {
+		return invalidString
+	}
+
+	var builder strings.Builder
+	indexWidth := len(strconv.Itoa(len(items)))
+	for i, item := range items {
+		member := fmt.Sprintf("%v", item)
+		indexStr := fmt.Sprintf("%*d) ", indexWidth, i+1)
+		builder.WriteString(indexStr)
+		builder.WriteString(member + "\n")
+	}
+
+	return builder.String()
+}

--- a/internal/proto/renderer.go
+++ b/internal/proto/renderer.go
@@ -10,7 +10,6 @@ var respNil = "(nil)"
 var emptyList = "(empty list or set)"
 var invalidString = "(error) invalid type"
 
-// Define command groups as `map[string]struct{}` for efficient lookups
 var simpleStringCommands = map[string]struct{}{
 	"AUTH":    {},
 	"SELECT":  {},
@@ -20,43 +19,78 @@ var simpleStringCommands = map[string]struct{}{
 	"SET":     {},
 	"PFMERGE": {},
 	"FLUSHDB": {},
+	"LSET":    {},
+	"LTRIM":   {},
+	"MIGRATE": {},
 }
 
 var intCommands = map[string]struct{}{
-	"COPY":         {},
-	"DEL":          {},
-	"EXISTS":       {},
-	"EXPIRE":       {},
-	"EXPIREAT":     {},
-	"EXPIRETIME":   {},
-	"PERSIST":      {},
-	"PTTL":         {},
-	"TTL":          {},
-	"TOUCH":        {},
-	"HDEL":         {},
-	"HEXISTS":      {},
-	"HINCRBY":      {},
-	"HSET":         {},
-	"HSETNX":       {},
-	"HSTRLEN":      {},
-	"PFADD":        {},
-	"PFCOUNT":      {},
-	"LPUSH":        {},
-	"RPUSH":        {},
-	"LLEN":         {},
-	"SADD":         {},
-	"SREM":         {},
-	"SCARD":        {},
-	"SETBIT":       {},
-	"SETNX":        {},
-	"INCR":         {},
-	"INCRBY":       {},
-	"DECR":         {},
-	"DECRBY":       {},
-	"APPEND":       {},
-	"ZADD":         {},
-	"HINCRBYFLOAT": {},
-	"BITPOS":       {},
+	"APPEND":           {},
+	"BITCOUNT":         {},
+	"BITOP":            {},
+	"BITPOS":           {},
+	"COPY":             {},
+	"DECR":             {},
+	"DECRBY":           {},
+	"DEL":              {},
+	"EXISTS":           {},
+	"EXPIRE":           {},
+	"EXPIREAT":         {},
+	"EXPIRETIME":       {},
+	"GEOADD":           {},
+	"GETBIT":           {},
+	"HDEL":             {},
+	"HEXISTS":          {},
+	"HINCRBY":          {},
+	"HLEN":             {},
+	"HSET":             {},
+	"HSETNX":           {},
+	"HSTRLEN":          {},
+	"INCR":             {},
+	"INCRBY":           {},
+	"LINSERT":          {},
+	"LLEN":             {},
+	"LPUSH":            {},
+	"LPUSHX":           {},
+	"LREM":             {},
+	"MOVE":             {},
+	"MSETNX":           {},
+	"PERSIST":          {},
+	"PEXPIRE":          {},
+	"PEXPIREAT":        {},
+	"PFADD":            {},
+	"PFCOUNT":          {},
+	"PTTL":             {},
+	"RENAMENX":         {},
+	"RPUSH":            {},
+	"RPUSHX":           {},
+	"SADD":             {},
+	"SCARD":            {},
+	"SDIFFSTORE":       {},
+	"SETBIT":           {},
+	"SETNX":            {},
+	"SETRANGE":         {},
+	"SINTERSTORE":      {},
+	"SISMEMBER":        {},
+	"SMOVE":            {},
+	"SREM":             {},
+	"STRLEN":           {},
+	"SUNIONSTORE":      {},
+	"TOUCH":            {},
+	"TTL":              {},
+	"UNLINK":           {},
+	"WAIT":             {},
+	"ZCARD":            {},
+	"ZCOUNT":           {},
+	"ZINTERSTORE":      {},
+	"ZLEXCOUNT":        {},
+	"ZRANK":            {},
+	"ZREM":             {},
+	"ZREMRANGEBYLEX":   {},
+	"ZREMRANGEBYRANK":  {},
+	"ZREMRANGEBYSCORE": {},
+	"ZREVRANK":         {},
+	"ZUNIONSTORE":      {},
 }
 
 var bulkStringCommands = map[string]struct{}{
@@ -74,21 +108,84 @@ var bulkStringCommands = map[string]struct{}{
 	"GETSET":       {},
 	"INCRBYFLOAT":  {},
 	"ZSCORE":       {},
+	"BLMOVE":       {},
+	"BRPOPLPUSH":   {},
+	"HMSET":        {},
+	"LINDEX":       {},
+	"PSETEX":       {},
+	"RANDOMKEY":    {},
+	"RPOPLPUSH":    {},
+	"SETEX":        {},
+	"ZINCRBY":      {},
 }
 
 var listCommands = map[string]struct{}{
-	"HELLO":      {},
-	"KEYS":       {},
-	"HKEYS":      {},
-	"HMGET":      {},
-	"HVALS":      {},
-	"HRANDFIELD": {},
-	"SMEMBERS":   {},
-	"SDIFF":      {},
-	"SINTER":     {},
-	"MGET":       {},
-	"BITFIELD":   {},
-	"COMMAND":    {},
+	"HELLO":             {},
+	"KEYS":              {},
+	"HKEYS":             {},
+	"HMGET":             {},
+	"HVALS":             {},
+	"HRANDFIELD":        {},
+	"SMEMBERS":          {},
+	"SDIFF":             {},
+	"SINTER":            {},
+	"MGET":              {},
+	"COMMAND":           {},
+	"BLPOP":             {},
+	"BRPOP":             {},
+	"BZPOPMAX":          {},
+	"BZPOPMIN":          {},
+	"GEOHASH":           {},
+	"GEOPOS":            {},
+	"GEORADIUS":         {},
+	"GEORADIUSBYMEMBER": {},
+	"GEOSEARCH":         {},
+	"GEOSEARCHSTORE":    {},
+	"LPOS":              {},
+	"LRANGE":            {},
+	"RPOP":              {},
+	"SORT":              {},
+	"SPOP":              {},
+	"SRANDMEMBER":       {},
+	"STRALGO":           {},
+	"SUNION":            {},
+	"ZRANGEBYLEX":       {},
+	"ZREVRANGE":         {},
+	"ZREVRANGEBYLEX":    {},
+	"ZREVRANGEBYSCORE":  {},
+}
+
+var membersCommands = map[string]struct{}{
+	"ZPOPMAX":       {},
+	"ZPOPMIN":       {},
+	"ZRANGE":        {},
+	"ZRANGEBYSCORE": {},
+}
+
+var stringOrIntCommands = map[string]struct{}{
+	"OBJECT": {},
+	"ZADD":   {},
+}
+
+var hashPairCommands = map[string]struct{}{
+	"HGETALL": {},
+}
+
+var listOrStringCommands = map[string]struct{}{
+	"BLPOP":             {},
+	"BRPOP":             {},
+	"BZPOPMAX":          {},
+	"BZPOPMIN":          {},
+	"GEORADIUS":         {},
+	"GEORADIUSBYMEMBER": {},
+	"HRANDFIELD":        {},
+	"LPOP":              {},
+	"LPOS":              {},
+	"RPOP":              {},
+	"SORT":              {},
+	"SPOP":              {},
+	"SRANDMEMBER":       {},
+	"STRALGO":           {},
 }
 
 func RenderOutput(cmdName string, cmdVal interface{}, cmdErr error) (interface{}, error) {
@@ -122,6 +219,18 @@ func getRender(commandName string) func(value interface{}) interface{} {
 	if _, exists := listCommands[commandUpper]; exists {
 		return renderList
 	}
+	if _, exists := membersCommands[commandUpper]; exists {
+		return renderMembers
+	}
+	if _, exists := stringOrIntCommands[commandUpper]; exists {
+		return renderStringOrInt
+	}
+	if _, exists := hashPairCommands[commandUpper]; exists {
+		return renderHashPairs
+	}
+	if _, exists := listOrStringCommands[commandUpper]; exists {
+		return renderListOrString
+	}
 
 	return nil
 }
@@ -154,7 +263,7 @@ func renderBulkString(value interface{}) interface{} {
 		return renderInt(result)
 	}
 
-	return fmt.Sprintf("%v", value)
+	return fmt.Sprintf("\"%v\"", value)
 }
 
 func renderInt(value interface{}) interface{} {
@@ -199,6 +308,7 @@ func renderListOrString(value interface{}) interface{} {
 	if items, ok := value.([]interface{}); ok {
 		return renderList(items)
 	}
+
 	return renderBulkString(value)
 }
 
@@ -206,6 +316,7 @@ func renderStringOrInt(value interface{}) interface{} {
 	if intValue, ok := value.(int); ok {
 		return renderInt(intValue)
 	}
+
 	return renderBulkString(value)
 }
 
@@ -246,26 +357,6 @@ func renderHashPairs(value interface{}) interface{} {
 		valueStr := strings.Repeat(" ", len(indexStr)) + value
 		builder.WriteString(valueStr + "\n")
 	}
-	return builder.String()
-}
-
-func commandHscan(value interface{}) interface{} {
-	scanResult, ok := value.([]interface{})
-	if !ok || len(scanResult) < 2 {
-		return "(error) invalid type or format"
-	}
-
-	cursor := fmt.Sprintf("%v", scanResult[0])
-	items, ok := scanResult[1].([]interface{})
-	if !ok {
-		return "(error) invalid scan items format"
-	}
-
-	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("(cursor) %s\n", cursor))
-	renderedItems := renderHashPairs(items)
-	builder.WriteString(fmt.Sprintf("%s", renderedItems))
-
 	return builder.String()
 }
 

--- a/options.go
+++ b/options.go
@@ -153,6 +153,10 @@ type Options struct {
 
 	// Add suffix to client name. Default is empty.
 	IdentitySuffix string
+
+	// Enables pretty response
+	// Currently only supported for .Do() command
+	EnablePrettyResponse bool
 }
 
 func (opt *Options) init() {

--- a/redis.go
+++ b/redis.go
@@ -673,6 +673,12 @@ func (c *Client) Conn() *Conn {
 func (c *Client) Do(ctx context.Context, args ...interface{}) *Cmd {
 	cmd := NewCmd(ctx, args...)
 	_ = c.Process(ctx, cmd)
+
+	// If pretty printing is enabled, call the pretty rendering function
+	if c.opt.EnablePrettyResponse {
+		cmd.PrettyRender()
+	}
+
 	return cmd
 }
 


### PR DESCRIPTION
Example responses rendered with `EnablePrettyResponse` set to `true`:
```
dice > GET k1
(nil)
dice > SET k1 v1
OK
dice > RENAME k1 k2
OK
dice > GET k2
"v1"
dice > INCR k
(integer) 1
dice > ECHO HELLO
"HELLO"
dice > HSET myhash field1 "Hello"
(integer) 0
dice > HSET myhash field2 "World"
(integer) 0
dice > HGETALL myhash
1) field1
"\"Hello\""
2) field2
"\"World\""
dice > RPUSH mylist "one" "two" "three" "four" "five"
(integer) 5
dice > LPOP mylist
""one""
dice > ZADD myzset 1 "one" 2 "two" 3 "three"
(integer) 3
dice > ZRANGE myzset 0 -1
1) "one"
2) "two"
3) "three"
dice > COMMAND COUNT
(integer) 119
dice > COMMAND GETKEYS MSET a b c d e f
1) "a"
2) "c"
3) "e"
dice ~$
```