### PR TITLE
Bug fix for variadic argument usage in `NewSliceCmd` call in `_unwatchCommand` function

### DIFF
--- a/watch_connection.go
+++ b/watch_connection.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/dicedb/dicedb-go/internal"
-	"github.com/dicedb/dicedb-go/internal/pool"
-	"github.com/dicedb/dicedb-go/internal/proto"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dicedb/dicedb-go/internal"
+	"github.com/dicedb/dicedb-go/internal/pool"
+	"github.com/dicedb/dicedb-go/internal/proto"
 )
 
 // WatchResult represents a message received via WatchConn.
@@ -582,6 +583,6 @@ func (w *WatchConn) _unwatchCommand(ctx context.Context, cn *pool.Conn, cmdName 
 	cmdArgs := make([]interface{}, 0, 2+len(args))
 	cmdArgs = append(cmdArgs, cmdName)
 	cmdArgs = append(cmdArgs, args...)
-	cmd := NewSliceCmd(ctx, cmdArgs)
+	cmd := NewSliceCmd(ctx, cmdArgs...)
 	return w.writeCmd(ctx, cn, cmd)
 }


### PR DESCRIPTION
In `_unwatchCommand` we are passing `cmdArgs` as an array to `NewSliceCmd` instead of unpacking it which leads to following error

```
redis: can't marshal []interface {} (implement encoding.BinaryMarshaler)
```