### PR TITLE
fix: rename all error messages to not use redis

### DIFF
--- a/bitmap_commands.go
+++ b/bitmap_commands.go
@@ -54,7 +54,7 @@ func (c cmdable) BitCount(ctx context.Context, key string, bitCount *BitCount) *
 		if bitCount.Unit != "" {
 			if bitCount.Unit != BitCountIndexByte && bitCount.Unit != BitCountIndexBit {
 				cmd := NewIntCmd(ctx)
-				cmd.SetErr(errors.New("redis: invalid bitcount index"))
+				cmd.SetErr(errors.New("err: invalid bitcount index"))
 				return cmd
 			}
 			args = append(args, bitCount.Unit)

--- a/command.go
+++ b/command.go
@@ -248,7 +248,7 @@ func toString(val interface{}) (string, error) {
 	case string:
 		return val, nil
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for String", val)
+		err := fmt.Errorf("err: unexpected type=%T for String", val)
 		return "", err
 	}
 }
@@ -263,7 +263,7 @@ func (cmd *Cmd) Int() (int, error) {
 	case string:
 		return strconv.Atoi(val)
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for Int", val)
+		err := fmt.Errorf("err: unexpected type=%T for Int", val)
 		return 0, err
 	}
 }
@@ -282,7 +282,7 @@ func toInt64(val interface{}) (int64, error) {
 	case string:
 		return strconv.ParseInt(val, 10, 64)
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for Int64", val)
+		err := fmt.Errorf("err: unexpected type=%T for Int64", val)
 		return 0, err
 	}
 }
@@ -301,7 +301,7 @@ func toUint64(val interface{}) (uint64, error) {
 	case string:
 		return strconv.ParseUint(val, 10, 64)
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for Uint64", val)
+		err := fmt.Errorf("err: unexpected type=%T for Uint64", val)
 		return 0, err
 	}
 }
@@ -324,7 +324,7 @@ func toFloat32(val interface{}) (float32, error) {
 		}
 		return float32(f), nil
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for Float32", val)
+		err := fmt.Errorf("err: unexpected type=%T for Float32", val)
 		return 0, err
 	}
 }
@@ -343,7 +343,7 @@ func toFloat64(val interface{}) (float64, error) {
 	case string:
 		return strconv.ParseFloat(val, 64)
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for Float64", val)
+		err := fmt.Errorf("err: unexpected type=%T for Float64", val)
 		return 0, err
 	}
 }
@@ -364,7 +364,7 @@ func toBool(val interface{}) (bool, error) {
 	case string:
 		return strconv.ParseBool(val)
 	default:
-		err := fmt.Errorf("redis: unexpected type=%T for Bool", val)
+		err := fmt.Errorf("err: unexpected type=%T for Bool", val)
 		return false, err
 	}
 }
@@ -377,7 +377,7 @@ func (cmd *Cmd) Slice() ([]interface{}, error) {
 	case []interface{}:
 		return val, nil
 	default:
-		return nil, fmt.Errorf("redis: unexpected type=%T for Slice", val)
+		return nil, fmt.Errorf("err: unexpected type=%T for Slice", val)
 	}
 }
 
@@ -1876,7 +1876,7 @@ func (cmd *XAutoClaimCmd) readReply(rd *proto.Reader) error {
 		3: // Redis 7:
 		// ok
 	default:
-		return fmt.Errorf("redis: got %d elements in XAutoClaim reply, wanted 2/3", n)
+		return fmt.Errorf("err: got %d elements in XAutoClaim reply, wanted 2/3", n)
 	}
 
 	cmd.start, err = rd.ReadString()
@@ -1946,7 +1946,7 @@ func (cmd *XAutoClaimJustIDCmd) readReply(rd *proto.Reader) error {
 		3: // Redis 7:
 		// ok
 	default:
-		return fmt.Errorf("redis: got %d elements in XAutoClaimJustID reply, wanted 2/3", n)
+		return fmt.Errorf("err: got %d elements in XAutoClaimJustID reply, wanted 2/3", n)
 	}
 
 	cmd.start, err = rd.ReadString()
@@ -2051,7 +2051,7 @@ func (cmd *XInfoConsumersCmd) readReply(rd *proto.Reader) error {
 				inactive, err = rd.ReadInt()
 				cmd.val[i].Inactive = time.Duration(inactive) * time.Millisecond
 			default:
-				return fmt.Errorf("redis: unexpected content %s in XINFO CONSUMERS reply", key)
+				return fmt.Errorf("err: unexpected content %s in XINFO CONSUMERS reply", key)
 			}
 			if err != nil {
 				return err
@@ -2162,7 +2162,7 @@ func (cmd *XInfoGroupsCmd) readReply(rd *proto.Reader) error {
 					return err
 				}
 			default:
-				return fmt.Errorf("redis: unexpected key %q in XINFO GROUPS reply", key)
+				return fmt.Errorf("err: unexpected key %q in XINFO GROUPS reply", key)
 			}
 		}
 	}
@@ -2281,7 +2281,7 @@ func (cmd *XInfoStreamCmd) readReply(rd *proto.Reader) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("redis: unexpected key %q in XINFO STREAM reply", key)
+			return fmt.Errorf("err: unexpected key %q in XINFO STREAM reply", key)
 		}
 	}
 	return nil
@@ -2425,7 +2425,7 @@ func (cmd *XInfoStreamFullCmd) readReply(rd *proto.Reader) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("redis: unexpected key %q in XINFO STREAM FULL reply", key)
+			return fmt.Errorf("err: unexpected key %q in XINFO STREAM FULL reply", key)
 		}
 	}
 	return nil
@@ -2490,7 +2490,7 @@ func readStreamGroups(rd *proto.Reader) ([]XInfoStreamGroup, error) {
 					return nil, err
 				}
 			default:
-				return nil, fmt.Errorf("redis: unexpected key %q in XINFO STREAM FULL reply", key)
+				return nil, fmt.Errorf("err: unexpected key %q in XINFO STREAM FULL reply", key)
 			}
 		}
 
@@ -2615,7 +2615,7 @@ func readXInfoStreamConsumers(rd *proto.Reader) ([]XInfoStreamConsumer, error) {
 					c.Pending = append(c.Pending, p)
 				}
 			default:
-				return nil, fmt.Errorf("redis: unexpected content %s "+
+				return nil, fmt.Errorf("err: unexpected content %s "+
 					"in XINFO STREAM FULL reply", cKey)
 			}
 			if err != nil {
@@ -2892,7 +2892,7 @@ func (cmd *ClusterSlotsCmd) readReply(rd *proto.Reader) error {
 			return err
 		}
 		if n < 2 {
-			return fmt.Errorf("redis: got %d elements in cluster info, expected at least 2", n)
+			return fmt.Errorf("err: got %d elements in cluster info, expected at least 2", n)
 		}
 
 		start, err := rd.ReadInt()
@@ -3441,7 +3441,7 @@ func (cmd *CommandsInfoCmd) readReply(rd *proto.Reader) error {
 		case numArgRedis5, numArgRedis6, numArgRedis7:
 			// ok
 		default:
-			return fmt.Errorf("redis: got %d elements in COMMAND reply, wanted 6/7/10", nn)
+			return fmt.Errorf("err: got %d elements in COMMAND reply, wanted 6/7/10", nn)
 		}
 
 		cmdInfo := &CommandInfo{}
@@ -3623,7 +3623,7 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 			return err
 		}
 		if nn < 4 {
-			return fmt.Errorf("redis: got %d elements in slowlog get, expected at least 4", nn)
+			return fmt.Errorf("err: got %d elements in slowlog get, expected at least 4", nn)
 		}
 
 		if cmd.val[i].ID, err = rd.ReadInt(); err != nil {
@@ -3647,7 +3647,7 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 			return err
 		}
 		if cmdLen < 1 {
-			return fmt.Errorf("redis: got %d elements commands reply in slowlog get, expected at least 1", cmdLen)
+			return fmt.Errorf("err: got %d elements commands reply in slowlog get, expected at least 1", cmdLen)
 		}
 
 		cmd.val[i].Args = make([]string, cmdLen)
@@ -4157,7 +4157,7 @@ func (cmd *FunctionListCmd) readReply(rd *proto.Reader) (err error) {
 			case "library_code":
 				library.Code, err = rd.ReadString()
 			default:
-				return fmt.Errorf("redis: function list unexpected key %s", key)
+				return fmt.Errorf("err: function list unexpected key %s", key)
 			}
 
 			if err != nil {
@@ -4214,7 +4214,7 @@ func (cmd *FunctionListCmd) readFunctions(rd *proto.Reader) ([]Function, error) 
 					}
 				}
 			default:
-				return nil, fmt.Errorf("redis: function list unexpected key %s", key)
+				return nil, fmt.Errorf("err: function list unexpected key %s", key)
 			}
 		}
 
@@ -4320,7 +4320,7 @@ func (cmd *FunctionStatsCmd) readReply(rd *proto.Reader) (err error) {
 		case "all_running_scripts": // Redis Enterprise only
 			result.allrs, result.isRunning, err = cmd.readRunningScripts(rd)
 		default:
-			return fmt.Errorf("redis: function stats unexpected key %s", key)
+			return fmt.Errorf("err: function stats unexpected key %s", key)
 		}
 
 		if err != nil {
@@ -4356,7 +4356,7 @@ func (cmd *FunctionStatsCmd) readRunningScript(rd *proto.Reader) (RunningScript,
 		case "command":
 			runningScript.Command, err = cmd.readCommand(rd)
 		default:
-			return RunningScript{}, false, fmt.Errorf("redis: function stats unexpected running_script key %s", key)
+			return RunningScript{}, false, fmt.Errorf("err: function stats unexpected running_script key %s", key)
 		}
 
 		if err != nil {
@@ -4383,7 +4383,7 @@ func (cmd *FunctionStatsCmd) readEngines(rd *proto.Reader) ([]Engine, error) {
 
 		err = rd.ReadFixedMapLen(2)
 		if err != nil {
-			return nil, fmt.Errorf("redis: function stats unexpected %s engine map length", engine.Language)
+			return nil, fmt.Errorf("err: function stats unexpected %s engine map length", engine.Language)
 		}
 
 		for i := 0; i < 2; i++ {
@@ -4779,7 +4779,7 @@ func (cmd *ClusterLinksCmd) readReply(rd *proto.Reader) error {
 			case "send-buffer-used":
 				cmd.val[i].SendBufferUsed, err = rd.ReadInt()
 			default:
-				return fmt.Errorf("redis: unexpected key %q in CLUSTER LINKS reply", key)
+				return fmt.Errorf("err: unexpected key %q in CLUSTER LINKS reply", key)
 			}
 
 			if err != nil {
@@ -4924,7 +4924,7 @@ func (cmd *ClusterShardsCmd) readReply(rd *proto.Reader) error {
 						case "health":
 							cmd.val[i].Nodes[k].Health, err = rd.ReadString()
 						default:
-							return fmt.Errorf("redis: unexpected key %q in CLUSTER SHARDS node reply", nodeKey)
+							return fmt.Errorf("err: unexpected key %q in CLUSTER SHARDS node reply", nodeKey)
 						}
 
 						if err != nil {
@@ -4933,7 +4933,7 @@ func (cmd *ClusterShardsCmd) readReply(rd *proto.Reader) error {
 					}
 				}
 			default:
-				return fmt.Errorf("redis: unexpected key %q in CLUSTER SHARDS reply", key)
+				return fmt.Errorf("err: unexpected key %q in CLUSTER SHARDS reply", key)
 			}
 		}
 	}
@@ -5148,7 +5148,7 @@ func parseClientInfo(txt string) (info *ClientInfo, err error) {
 	for _, s := range strings.Split(txt, " ") {
 		kv := strings.Split(s, "=")
 		if len(kv) != 2 {
-			return nil, fmt.Errorf("redis: unexpected client info data (%s)", s)
+			return nil, fmt.Errorf("err: unexpected client info data (%s)", s)
 		}
 		key, val := kv[0], kv[1]
 
@@ -5215,7 +5215,7 @@ func parseClientInfo(txt string) (info *ClientInfo, err error) {
 				case 'T':
 					info.Flags |= ClientNoTouch
 				default:
-					return nil, fmt.Errorf("redis: unexpected client info flags(%s)", string(val[i]))
+					return nil, fmt.Errorf("err: unexpected client info flags(%s)", string(val[i]))
 				}
 			}
 		case "db":
@@ -5265,7 +5265,7 @@ func parseClientInfo(txt string) (info *ClientInfo, err error) {
 		case "lib-ver":
 			info.LibVer = val
 		default:
-			return nil, fmt.Errorf("redis: unexpected client info key(%s)", key)
+			return nil, fmt.Errorf("err: unexpected client info key(%s)", key)
 		}
 
 		if err != nil {
@@ -5373,7 +5373,7 @@ func (cmd *ACLLogCmd) readReply(rd *proto.Reader) error {
 			case "timestamp-last-updated":
 				entry.TimestampLastUpdated, err = rd.ReadInt()
 			default:
-				return fmt.Errorf("redis: unexpected key %q in ACL LOG reply", key)
+				return fmt.Errorf("err: unexpected key %q in ACL LOG reply", key)
 			}
 
 			if err != nil {

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -129,5 +129,5 @@ func ExampleClient_hget() {
 	// Output:
 	// 1
 	// foo
-	// redis: nil
+	// err: nil
 }

--- a/doctests/list_tutorial_test.go
+++ b/doctests/list_tutorial_test.go
@@ -364,7 +364,7 @@ func ExampleClient_llen() {
 //	res26, err := rdb.RPop(ctx, "bikes:repairs").Result()
 //
 //	if err != nil {
-//		fmt.Println(err) // >>> redis: nil
+//		fmt.Println(err) // >>> err: nil
 //	}
 //
 //	fmt.Println(res26) // >>> <empty string>
@@ -376,7 +376,7 @@ func ExampleClient_llen() {
 //	// bike:3
 //	// bike:1
 //	// bike:2
-//	// redis: nil
+//	// err: nil
 //	//
 //}
 
@@ -511,7 +511,7 @@ func ExampleClient_llen() {
 //	res36, err := rdb.BRPop(ctx, 1, "bikes:repairs").Result()
 //
 //	if err != nil {
-//		fmt.Println(err) // >>> redis: nil
+//		fmt.Println(err) // >>> err: nil
 //	}
 //
 //	fmt.Println(res36) // >>> []
@@ -521,7 +521,7 @@ func ExampleClient_llen() {
 //	// 2
 //	// [bikes:repairs bike:2]
 //	// [bikes:repairs bike:1]
-//	// redis: nil
+//	// err: nil
 //	// []
 //}
 
@@ -713,7 +713,7 @@ func ExampleClient_llen() {
 //	res50, err := rdb.LPop(ctx, "bikes:repairs").Result()
 //
 //	if err != nil {
-//		fmt.Println(err) // >>> redis: nil
+//		fmt.Println(err) // >>> err: nil
 //	}
 //
 //	fmt.Println(res50) // >>> <empty string>
@@ -722,7 +722,7 @@ func ExampleClient_llen() {
 //	// Output:
 //	// 0
 //	// 0
-//	// redis: nil
+//	// err: nil
 //	//
 //}
 //

--- a/example/scan-struct/README.md
+++ b/example/scan-struct/README.md
@@ -7,5 +7,5 @@ go run .
 ```
 
 See
-[Redis: Scanning hash fields into a struct](https://redis.uptrace.dev/guide/scanning-hash-fields.html)
+[err: Scanning hash fields into a struct](https://redis.uptrace.dev/guide/scanning-hash-fields.html)
 for details.

--- a/example_test.go
+++ b/example_test.go
@@ -606,7 +606,7 @@ func ExampleClient_TxPipeline() {
 //	n, err = IncrByXX.Run(ctx, rdb, []string{"xx_counter"}, 2).Result()
 //	fmt.Println(n, err)
 //
-//	// Output: <nil> redis: nil
+//	// Output: <nil> err: nil
 //	// 42 <nil>
 //}
 
@@ -619,13 +619,13 @@ func Example_customCommand() {
 
 	v, err := Get(ctx, rdb, "key_does_not_exist").Result()
 	fmt.Printf("%q %s", v, err)
-	// Output: "" redis: nil
+	// Output: "" err: nil
 }
 
 func Example_customCommand2() {
 	v, err := rdb.Do(ctx, "get", "key_does_not_exist").Text()
 	fmt.Printf("%q %s", v, err)
-	// Output: "" redis: nil
+	// Output: "" err: nil
 }
 
 //func ExampleScanIterator() {

--- a/internal/log.go
+++ b/internal/log.go
@@ -22,5 +22,5 @@ func (l *logger) Printf(ctx context.Context, format string, v ...interface{}) {
 // Logger calls Output to print to the stderr.
 // Arguments are handled in the manner of fmt.Print.
 var Logger Logging = &logger{
-	log: log.New(os.Stderr, "redis: ", log.LstdFlags|log.Lshortfile),
+	log: log.New(os.Stderr, "err: ", log.LstdFlags|log.Lshortfile),
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -13,14 +13,14 @@ import (
 
 var (
 	// ErrClosed performs any operation on the closed client will return this error.
-	ErrClosed = errors.New("redis: client is closed")
+	ErrClosed = errors.New("err: client is closed")
 
 	// ErrPoolExhausted is returned from a pool connection method
 	// when the maximum number of database connections in the pool has been reached.
-	ErrPoolExhausted = errors.New("redis: connection pool exhausted")
+	ErrPoolExhausted = errors.New("err: connection pool exhausted")
 
 	// ErrPoolTimeout timed out waiting to get a connection from the connection pool.
-	ErrPoolTimeout = errors.New("redis: connection pool timeout")
+	ErrPoolTimeout = errors.New("err: connection pool timeout")
 )
 
 var timers = sync.Pool{

--- a/internal/pool/pool_sticky.go
+++ b/internal/pool/pool_sticky.go
@@ -20,7 +20,7 @@ type BadConnError struct {
 var _ error = (*BadConnError)(nil)
 
 func (e BadConnError) Error() string {
-	s := "redis: Conn is in a bad state"
+	s := "err: Conn is in a bad state"
 	if e.wrapped != nil {
 		s += ": " + e.wrapped.Error()
 	}
@@ -93,7 +93,7 @@ func (p *StickyConnPool) Get(ctx context.Context) (*Conn, error) {
 			panic("not reached")
 		}
 	}
-	return nil, fmt.Errorf("redis: StickyConnPool.Get: infinite loop")
+	return nil, fmt.Errorf("err: StickyConnPool.Get: infinite loop")
 }
 
 func (p *StickyConnPool) Put(ctx context.Context, cn *Conn) {
@@ -143,7 +143,7 @@ func (p *StickyConnPool) Close() error {
 		}
 	}
 
-	return errors.New("redis: StickyConnPool.Close: infinite loop")
+	return errors.New("err: StickyConnPool.Close: infinite loop")
 }
 
 func (p *StickyConnPool) Reset(ctx context.Context) error {
@@ -159,12 +159,12 @@ func (p *StickyConnPool) Reset(ctx context.Context) error {
 		p.pool.Remove(ctx, cn, ErrClosed)
 		p._badConnError.Store(BadConnError{wrapped: nil})
 	default:
-		return errors.New("redis: StickyConnPool does not have a Conn")
+		return errors.New("err: StickyConnPool does not have a Conn")
 	}
 
 	if !atomic.CompareAndSwapUint32(&p.state, stateInited, stateDefault) {
 		state := atomic.LoadUint32(&p.state)
-		return fmt.Errorf("redis: invalid StickyConnPool state: %d", state)
+		return fmt.Errorf("err: invalid StickyConnPool state: %d", state)
 	}
 
 	return nil

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -38,7 +38,7 @@ const (
 
 //------------------------------------------------------------------------------
 
-const Nil = RedisError("redis: nil") // nolint:errname
+const Nil = RedisError("err: nil") // nolint:errname
 
 type RedisError string
 
@@ -146,7 +146,7 @@ func (r *Reader) readLine() ([]byte, error) {
 		b = full
 	}
 	if len(b) <= 2 || b[len(b)-1] != '\n' || b[len(b)-2] != '\r' {
-		return nil, fmt.Errorf("redis: invalid reply: %q", b)
+		return nil, fmt.Errorf("err: invalid reply: %q", b)
 	}
 	return b[:len(b)-2], nil
 }
@@ -179,7 +179,7 @@ func (r *Reader) ReadReply() (interface{}, error) {
 	case RespMap:
 		return r.readMap(line)
 	}
-	return nil, fmt.Errorf("redis: can't parse %.100q", line)
+	return nil, fmt.Errorf("err: can't parse %.100q", line)
 }
 
 func (r *Reader) readFloat(line []byte) (float64, error) {
@@ -202,7 +202,7 @@ func (r *Reader) readBool(line []byte) (bool, error) {
 	case "f":
 		return false, nil
 	}
-	return false, fmt.Errorf("redis: can't parse bool reply: %q", line)
+	return false, fmt.Errorf("err: can't parse bool reply: %q", line)
 }
 
 func (r *Reader) readBigInt(line []byte) (*big.Int, error) {
@@ -210,7 +210,7 @@ func (r *Reader) readBigInt(line []byte) (*big.Int, error) {
 	if i, ok := i.SetString(string(line[1:]), 10); ok {
 		return i, nil
 	}
-	return nil, fmt.Errorf("redis: can't parse bigInt reply: %q", line)
+	return nil, fmt.Errorf("err: can't parse bigInt reply: %q", line)
 }
 
 func (r *Reader) readStringReply(line []byte) (string, error) {
@@ -234,7 +234,7 @@ func (r *Reader) readVerb(line []byte) (string, error) {
 		return "", err
 	}
 	if len(s) < 4 || s[3] != ':' {
-		return "", fmt.Errorf("redis: can't parse verbatim string reply: %q", line)
+		return "", fmt.Errorf("err: can't parse verbatim string reply: %q", line)
 	}
 	return s[4:], nil
 }
@@ -318,7 +318,7 @@ func (r *Reader) ReadInt() (int64, error) {
 		}
 		return b.Int64(), nil
 	}
-	return 0, fmt.Errorf("redis: can't parse int reply: %.100q", line)
+	return 0, fmt.Errorf("err: can't parse int reply: %.100q", line)
 }
 
 func (r *Reader) ReadUint() (uint64, error) {
@@ -345,7 +345,7 @@ func (r *Reader) ReadUint() (uint64, error) {
 		}
 		return b.Uint64(), nil
 	}
-	return 0, fmt.Errorf("redis: can't parse uint reply: %.100q", line)
+	return 0, fmt.Errorf("err: can't parse uint reply: %.100q", line)
 }
 
 func (r *Reader) ReadFloat() (float64, error) {
@@ -365,7 +365,7 @@ func (r *Reader) ReadFloat() (float64, error) {
 		}
 		return strconv.ParseFloat(s, 64)
 	}
-	return 0, fmt.Errorf("redis: can't parse float reply: %.100q", line)
+	return 0, fmt.Errorf("err: can't parse float reply: %.100q", line)
 }
 
 func (r *Reader) ReadString() (string, error) {
@@ -391,7 +391,7 @@ func (r *Reader) ReadString() (string, error) {
 		}
 		return b.String(), nil
 	}
-	return "", fmt.Errorf("redis: can't parse reply=%.100q reading string", line)
+	return "", fmt.Errorf("err: can't parse reply=%.100q reading string", line)
 }
 
 func (r *Reader) ReadBool() (bool, error) {
@@ -417,7 +417,7 @@ func (r *Reader) ReadFixedArrayLen(fixedLen int) error {
 		return err
 	}
 	if n != fixedLen {
-		return fmt.Errorf("redis: got %d elements in the array, wanted %d", n, fixedLen)
+		return fmt.Errorf("err: got %d elements in the array, wanted %d", n, fixedLen)
 	}
 	return nil
 }
@@ -432,7 +432,7 @@ func (r *Reader) ReadArrayLen() (int, error) {
 	case RespArray, RespSet, RespPush:
 		return replyLen(line)
 	default:
-		return 0, fmt.Errorf("redis: can't parse array/set/push reply: %.100q", line)
+		return 0, fmt.Errorf("err: can't parse array/set/push reply: %.100q", line)
 	}
 }
 
@@ -443,7 +443,7 @@ func (r *Reader) ReadFixedMapLen(fixedLen int) error {
 		return err
 	}
 	if n != fixedLen {
-		return fmt.Errorf("redis: got %d elements in the map, wanted %d", n, fixedLen)
+		return fmt.Errorf("err: got %d elements in the map, wanted %d", n, fixedLen)
 	}
 	return nil
 }
@@ -467,11 +467,11 @@ func (r *Reader) ReadMapLen() (int, error) {
 			return 0, err
 		}
 		if n%2 != 0 {
-			return 0, fmt.Errorf("redis: the length of the array must be a multiple of 2, got: %d", n)
+			return 0, fmt.Errorf("err: the length of the array must be a multiple of 2, got: %d", n)
 		}
 		return n / 2, nil
 	default:
-		return 0, fmt.Errorf("redis: can't parse map reply: %.100q", line)
+		return 0, fmt.Errorf("err: can't parse map reply: %.100q", line)
 	}
 }
 
@@ -487,7 +487,7 @@ func (r *Reader) DiscardNext() error {
 // Discard the data represented by line.
 func (r *Reader) Discard(line []byte) (err error) {
 	if len(line) == 0 {
-		return errors.New("redis: invalid line")
+		return errors.New("err: invalid line")
 	}
 	switch line[0] {
 	case RespStatus, RespError, RespInt, RespNil, RespFloat, RespBool, RespBigInt:
@@ -521,7 +521,7 @@ func (r *Reader) Discard(line []byte) (err error) {
 		return nil
 	}
 
-	return fmt.Errorf("redis: can't parse %.100q", line)
+	return fmt.Errorf("err: can't parse %.100q", line)
 }
 
 func replyLen(line []byte) (n int, err error) {
@@ -531,7 +531,7 @@ func replyLen(line []byte) (n int, err error) {
 	}
 
 	if n < -1 {
-		return 0, fmt.Errorf("redis: invalid reply: %q", line)
+		return 0, fmt.Errorf("err: invalid reply: %q", line)
 	}
 
 	switch line[0] {

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -16,7 +16,7 @@ import (
 func Scan(b []byte, v interface{}) error {
 	switch v := v.(type) {
 	case nil:
-		return fmt.Errorf("redis: Scan(nil)")
+		return fmt.Errorf("err: Scan(nil)")
 	case *string:
 		*v = util.BytesToString(b)
 		return nil
@@ -122,28 +122,28 @@ func Scan(b []byte, v interface{}) error {
 		return nil
 	default:
 		return fmt.Errorf(
-			"redis: can't unmarshal %T (consider implementing BinaryUnmarshaler)", v)
+			"err: can't unmarshal %T (consider implementing BinaryUnmarshaler)", v)
 	}
 }
 
 func ScanSlice(data []string, slice interface{}) error {
 	v := reflect.ValueOf(slice)
 	if !v.IsValid() {
-		return fmt.Errorf("redis: ScanSlice(nil)")
+		return fmt.Errorf("err: ScanSlice(nil)")
 	}
 	if v.Kind() != reflect.Ptr {
-		return fmt.Errorf("redis: ScanSlice(non-pointer %T)", slice)
+		return fmt.Errorf("err: ScanSlice(non-pointer %T)", slice)
 	}
 	v = v.Elem()
 	if v.Kind() != reflect.Slice {
-		return fmt.Errorf("redis: ScanSlice(non-slice %T)", slice)
+		return fmt.Errorf("err: ScanSlice(non-slice %T)", slice)
 	}
 
 	next := makeSliceNextElemFunc(v)
 	for i, s := range data {
 		elem := next()
 		if err := Scan([]byte(s), elem.Addr().Interface()); err != nil {
-			err = fmt.Errorf("redis: ScanSlice index=%d value=%q failed: %w", i, s, err)
+			err = fmt.Errorf("err: ScanSlice index=%d value=%q failed: %w", i, s, err)
 			return err
 		}
 	}

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -142,7 +142,7 @@ func (w *Writer) WriteArg(v interface{}) error {
 		return w.bytes(v)
 	default:
 		return fmt.Errorf(
-			"redis: can't marshal %T (implement encoding.BinaryMarshaler)", v)
+			"err: can't marshal %T (implement encoding.BinaryMarshaler)", v)
 	}
 }
 

--- a/json.go
+++ b/json.go
@@ -112,7 +112,7 @@ func (cmd *JSONCmd) Expanded() (interface{}, error) {
 }
 
 func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
-	// nil response from JSON.(M)GET (cmd.baseCmd.err will be "redis: nil")
+	// nil response from JSON.(M)GET (cmd.baseCmd.err will be "err: nil")
 	if cmd.baseCmd.Err() == Nil {
 		cmd.val = ""
 		return Nil
@@ -550,7 +550,7 @@ func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interf
 			args = append(args, strings.ToUpper(mode))
 
 		default:
-			panic("redis: JSON.SET mode must be NX or XX")
+			panic("err: JSON.SET mode must be NX or XX")
 		}
 	}
 	cmd := NewStatusCmd(ctx, args...)

--- a/options.go
+++ b/options.go
@@ -296,7 +296,7 @@ func ParseURL(redisURL string) (*Options, error) {
 	case "unix":
 		return setupUnixConn(u)
 	default:
-		return nil, fmt.Errorf("redis: invalid URL scheme: %s", u.Scheme)
+		return nil, fmt.Errorf("err: invalid URL scheme: %s", u.Scheme)
 	}
 }
 
@@ -317,10 +317,10 @@ func setupTCPConn(u *url.URL) (*Options, error) {
 	case 1:
 		var err error
 		if o.DB, err = strconv.Atoi(f[0]); err != nil {
-			return nil, fmt.Errorf("redis: invalid database number: %q", f[0])
+			return nil, fmt.Errorf("err: invalid database number: %q", f[0])
 		}
 	default:
-		return nil, fmt.Errorf("redis: invalid URL path: %s", u.Path)
+		return nil, fmt.Errorf("err: invalid URL path: %s", u.Path)
 	}
 
 	if u.Scheme == "rediss" {
@@ -356,7 +356,7 @@ func setupUnixConn(u *url.URL) (*Options, error) {
 	}
 
 	if strings.TrimSpace(u.Path) == "" { // path is required with unix connection
-		return nil, errors.New("redis: empty unix socket path")
+		return nil, errors.New("err: empty unix socket path")
 	}
 	o.Addr = u.Path
 	o.Username, o.Password = getUserPassword(u)
@@ -397,7 +397,7 @@ func (o *queryOptions) int(name string) int {
 		return i
 	}
 	if o.err == nil {
-		o.err = fmt.Errorf("redis: invalid %s number: %s", name, err)
+		o.err = fmt.Errorf("err: invalid %s number: %s", name, err)
 	}
 	return 0
 }
@@ -420,7 +420,7 @@ func (o *queryOptions) duration(name string) time.Duration {
 		return dur
 	}
 	if o.err == nil {
-		o.err = fmt.Errorf("redis: invalid %s duration: %w", name, err)
+		o.err = fmt.Errorf("err: invalid %s duration: %w", name, err)
 	}
 	return 0
 }
@@ -433,7 +433,7 @@ func (o *queryOptions) bool(name string) bool {
 		return false
 	default:
 		if o.err == nil {
-			o.err = fmt.Errorf("redis: invalid %s boolean: expected true/false/1/0 or an empty string, got %q", name, s)
+			o.err = fmt.Errorf("err: invalid %s boolean: expected true/false/1/0 or an empty string, got %q", name, s)
 		}
 		return false
 	}
@@ -459,7 +459,7 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 	if tmp := q.string("db"); tmp != "" {
 		db, err := strconv.Atoi(tmp)
 		if err != nil {
-			return nil, fmt.Errorf("redis: invalid database number: %w", err)
+			return nil, fmt.Errorf("err: invalid database number: %w", err)
 		}
 		o.DB = db
 	}
@@ -494,7 +494,7 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 
 	// any parameters left?
 	if r := q.remaining(); len(r) > 0 {
-		return nil, fmt.Errorf("redis: unexpected option: %s", strings.Join(r, ", "))
+		return nil, fmt.Errorf("err: unexpected option: %s", strings.Join(r, ", "))
 	}
 
 	return o, nil

--- a/options_test.go
+++ b/options_test.go
@@ -76,40 +76,40 @@ func TestParseURL(t *testing.T) {
 		}, {
 			// invalid db format
 			url: "unix://foo:bar@/tmp/redis.sock?db=test",
-			err: errors.New(`redis: invalid database number: strconv.Atoi: parsing "test": invalid syntax`),
+			err: errors.New(`err: invalid database number: strconv.Atoi: parsing "test": invalid syntax`),
 		}, {
 			// invalid int value
 			url: "redis://localhost/?pool_size=five",
-			err: errors.New(`redis: invalid pool_size number: strconv.Atoi: parsing "five": invalid syntax`),
+			err: errors.New(`err: invalid pool_size number: strconv.Atoi: parsing "five": invalid syntax`),
 		}, {
 			// invalid bool value
 			url: "redis://localhost/?pool_fifo=yes",
-			err: errors.New(`redis: invalid pool_fifo boolean: expected true/false/1/0 or an empty string, got "yes"`),
+			err: errors.New(`err: invalid pool_fifo boolean: expected true/false/1/0 or an empty string, got "yes"`),
 		}, {
 			// it returns first error
 			url: "redis://localhost/?db=foo&pool_size=five",
-			err: errors.New(`redis: invalid database number: strconv.Atoi: parsing "foo": invalid syntax`),
+			err: errors.New(`err: invalid database number: strconv.Atoi: parsing "foo": invalid syntax`),
 		}, {
 			url: "redis://localhost/?abc=123",
-			err: errors.New("redis: unexpected option: abc"),
+			err: errors.New("err: unexpected option: abc"),
 		}, {
 			url: "redis://foo@localhost/?username=bar",
-			err: errors.New("redis: unexpected option: username"),
+			err: errors.New("err: unexpected option: username"),
 		}, {
 			url: "redis://localhost/?wrte_timout=10s&abc=123",
-			err: errors.New("redis: unexpected option: abc, wrte_timout"),
+			err: errors.New("err: unexpected option: abc, wrte_timout"),
 		}, {
 			url: "http://google.com",
-			err: errors.New("redis: invalid URL scheme: http"),
+			err: errors.New("err: invalid URL scheme: http"),
 		}, {
 			url: "redis://localhost/1/2/3/4",
-			err: errors.New("redis: invalid URL path: /1/2/3/4"),
+			err: errors.New("err: invalid URL path: /1/2/3/4"),
 		}, {
 			url: "12345",
-			err: errors.New("redis: invalid URL scheme: "),
+			err: errors.New("err: invalid URL scheme: "),
 		}, {
 			url: "redis://localhost/iamadatabase",
-			err: errors.New(`redis: invalid database number: "iamadatabase"`),
+			err: errors.New(`err: invalid database number: "iamadatabase"`),
 		},
 	}
 

--- a/osscluster.go
+++ b/osscluster.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dicedb/dicedb-go/internal/rand"
 )
 
-var errClusterNoNodes = fmt.Errorf("redis: cluster has no nodes")
+var errClusterNoNodes = fmt.Errorf("err: cluster has no nodes")
 
 // ClusterOptions are used to configure a cluster client and should be
 // passed to NewClusterClient.
@@ -207,7 +207,7 @@ func setupClusterConn(u *url.URL, host string, o *ClusterOptions) (*ClusterOptio
 	case "redis":
 		o.Username, o.Password = getUserPassword(u)
 	default:
-		return nil, fmt.Errorf("redis: invalid URL scheme: %s", u.Scheme)
+		return nil, fmt.Errorf("err: invalid URL scheme: %s", u.Scheme)
 	}
 
 	// retrieve the configuration from the query parameters
@@ -253,7 +253,7 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 	for _, addr := range addrs {
 		h, p, err := net.SplitHostPort(addr)
 		if err != nil || h == "" || p == "" {
-			return nil, fmt.Errorf("redis: unable to parse addr param: %s", addr)
+			return nil, fmt.Errorf("err: unable to parse addr param: %s", addr)
 		}
 
 		o.Addrs = append(o.Addrs, net.JoinHostPort(h, p))
@@ -261,7 +261,7 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 
 	// any parameters left?
 	if r := q.remaining(); len(r) > 0 {
-		return nil, fmt.Errorf("redis: unexpected option: %s", strings.Join(r, ", "))
+		return nil, fmt.Errorf("err: unexpected option: %s", strings.Join(r, ", "))
 	}
 
 	return o, nil
@@ -765,12 +765,12 @@ func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
 
 	// if all nodes are failing, we will pick the temporarily failing node with lowest latency
 	if minLatency < maximumNodeLatency && closestNode != nil {
-		internal.Logger.Printf(context.TODO(), "redis: all nodes are marked as failed, picking the temporarily failing node with lowest latency")
+		internal.Logger.Printf(context.TODO(), "err: all nodes are marked as failed, picking the temporarily failing node with lowest latency")
 		return closestNode, nil
 	}
 
 	// If all nodes are having the maximum latency(all pings are failing) - return a random node across the cluster
-	internal.Logger.Printf(context.TODO(), "redis: pings to all nodes are failing, picking a random node across the cluster")
+	internal.Logger.Printf(context.TODO(), "err: pings to all nodes are failing, picking a random node across the cluster")
 	return c.nodes.Random()
 }
 
@@ -1586,7 +1586,7 @@ func (c *ClusterClient) txPipelineReadQueued(
 	}
 
 	if line[0] != proto.RespArray {
-		return fmt.Errorf("redis: expected '*', but got line %q", line)
+		return fmt.Errorf("err: expected '*', but got line %q", line)
 	}
 
 	return nil
@@ -1623,13 +1623,13 @@ func (c *ClusterClient) cmdsMoved(
 
 func (c *ClusterClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	if len(keys) == 0 {
-		return fmt.Errorf("redis: Watch requires at least one key")
+		return fmt.Errorf("err: Watch requires at least one key")
 	}
 
 	slot := hashtag.Slot(keys[0])
 	for _, key := range keys[1:] {
 		if hashtag.Slot(key) != slot {
-			err := fmt.Errorf("redis: Watch requires all keys to be in the same slot")
+			err := fmt.Errorf("err: Watch requires all keys to be in the same slot")
 			return err
 		}
 	}

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1316,7 +1316,7 @@ func slotEqual(s1, s2 dicedb.ClusterSlot) bool {
 //
 //	It("Ping returns an error", func() {
 //		err := client.Ping(ctx).Err()
-//		Expect(err).To(MatchError("redis: cluster has no nodes"))
+//		Expect(err).To(MatchError("err: cluster has no nodes"))
 //	})
 //
 //	It("pipeline returns an error", func() {
@@ -1324,7 +1324,7 @@ func slotEqual(s1, s2 dicedb.ClusterSlot) bool {
 //			pipe.Ping(ctx)
 //			return nil
 //		})
-//		Expect(err).To(MatchError("redis: cluster has no nodes"))
+//		Expect(err).To(MatchError("err: cluster has no nodes"))
 //	})
 //})
 //
@@ -1554,23 +1554,23 @@ func slotEqual(s1, s2 dicedb.ClusterSlot) bool {
 //		}, {
 //			test: "InvalidQueryAddr",
 //			url:  "rediss://foo:bar@localhost:123?addr=rediss://foo:barr@localhost:1234",
-//			err:  errors.New(`redis: unable to parse addr param: rediss://foo:barr@localhost:1234`),
+//			err:  errors.New(`err: unable to parse addr param: rediss://foo:barr@localhost:1234`),
 //		}, {
 //			test: "InvalidInt",
 //			url:  "redis://localhost?pool_size=five",
-//			err:  errors.New(`redis: invalid pool_size number: strconv.Atoi: parsing "five": invalid syntax`),
+//			err:  errors.New(`err: invalid pool_size number: strconv.Atoi: parsing "five": invalid syntax`),
 //		}, {
 //			test: "InvalidBool",
 //			url:  "redis://localhost?pool_fifo=yes",
-//			err:  errors.New(`redis: invalid pool_fifo boolean: expected true/false/1/0 or an empty string, got "yes"`),
+//			err:  errors.New(`err: invalid pool_fifo boolean: expected true/false/1/0 or an empty string, got "yes"`),
 //		}, {
 //			test: "UnknownParam",
 //			url:  "redis://localhost?abc=123",
-//			err:  errors.New("redis: unexpected option: abc"),
+//			err:  errors.New("err: unexpected option: abc"),
 //		}, {
 //			test: "InvalidScheme",
 //			url:  "https://google.com",
-//			err:  errors.New("redis: invalid URL scheme: https"),
+//			err:  errors.New("err: invalid URL scheme: https"),
 //		},
 //	}
 //

--- a/pipeline.go
+++ b/pipeline.go
@@ -67,7 +67,7 @@ func (c *Pipeline) Len() int {
 func (c *Pipeline) Do(ctx context.Context, args ...interface{}) *Cmd {
 	cmd := NewCmd(ctx, args...)
 	if len(args) == 0 {
-		cmd.SetErr(errors.New("redis: please enter the command to be executed"))
+		cmd.SetErr(errors.New("err: please enter the command to be executed"))
 		return cmd
 	}
 	_ = c.Process(ctx, cmd)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -90,7 +90,7 @@ var _ = Describe("pipelining", func() {
 
 		It("should Exec, not Do", func() {
 			err := pipe.Do(ctx).Err()
-			Expect(err).To(Equal(errors.New("redis: please enter the command to be executed")))
+			Expect(err).To(Equal(errors.New("err: please enter the command to be executed")))
 		})
 	}
 

--- a/probabilistic.go
+++ b/probabilistic.go
@@ -344,7 +344,7 @@ func (cmd *BFInfoCmd) readReply(rd *proto.Reader) (err error) {
 		case "Expansion rate":
 			result.ExpansionRate, err = rd.ReadInt()
 		default:
-			return fmt.Errorf("redis: BLOOM.INFO unexpected key %s", key)
+			return fmt.Errorf("err: BLOOM.INFO unexpected key %s", key)
 		}
 
 		if err != nil {
@@ -648,7 +648,7 @@ func (cmd *CFInfoCmd) readReply(rd *proto.Reader) (err error) {
 			result.MaxIteration, err = rd.ReadInt()
 
 		default:
-			return fmt.Errorf("redis: CF.INFO unexpected key %s", key)
+			return fmt.Errorf("err: CF.INFO unexpected key %s", key)
 		}
 
 		if err != nil {
@@ -799,7 +799,7 @@ func (cmd *CMSInfoCmd) readReply(rd *proto.Reader) (err error) {
 		case "count":
 			result.Count, err = rd.ReadInt()
 		default:
-			return fmt.Errorf("redis: CMS.INFO unexpected key %s", key)
+			return fmt.Errorf("err: CMS.INFO unexpected key %s", key)
 		}
 
 		if err != nil {
@@ -994,7 +994,7 @@ func (cmd *TopKInfoCmd) readReply(rd *proto.Reader) (err error) {
 		case "decay":
 			result.Decay, err = rd.ReadFloat()
 		default:
-			return fmt.Errorf("redis: topk.info unexpected key %s", key)
+			return fmt.Errorf("err: topk.info unexpected key %s", key)
 		}
 
 		if err != nil {
@@ -1267,7 +1267,7 @@ func (cmd *TDigestInfoCmd) readReply(rd *proto.Reader) (err error) {
 		case "Memory usage":
 			result.MemoryUsage, err = rd.ReadInt()
 		default:
-			return fmt.Errorf("redis: tdigest.info unexpected key %s", key)
+			return fmt.Errorf("err: tdigest.info unexpected key %s", key)
 		}
 
 		if err != nil {

--- a/pubsub.go
+++ b/pubsub.go
@@ -165,7 +165,7 @@ func (c *PubSub) closeTheCn(reason error) error {
 		return nil
 	}
 	if !c.closed {
-		internal.Logger.Printf(c.getContext(), "redis: discarding bad PubSub connection: %s", reason)
+		internal.Logger.Printf(c.getContext(), "err: discarding bad PubSub connection: %s", reason)
 	}
 	err := c.closeConn(c.cn)
 	c.cn = nil
@@ -397,7 +397,7 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 					PayloadSlice: ss,
 				}, nil
 			default:
-				return nil, fmt.Errorf("redis: unsupported pubsub message payload: %T", payload)
+				return nil, fmt.Errorf("err: unsupported pubsub message payload: %T", payload)
 			}
 		case "pmessage":
 			return &Message{
@@ -410,10 +410,10 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 				Payload: reply[1].(string),
 			}, nil
 		default:
-			return nil, fmt.Errorf("redis: unsupported pubsub message: %q", kind)
+			return nil, fmt.Errorf("err: unsupported pubsub message: %q", kind)
 		}
 	default:
-		return nil, fmt.Errorf("redis: unsupported pubsub message: %#v", reply)
+		return nil, fmt.Errorf("err: unsupported pubsub message: %#v", reply)
 	}
 }
 
@@ -470,7 +470,7 @@ func (c *PubSub) ReceiveMessage(ctx context.Context) (*Message, error) {
 		case *Message:
 			return msg, nil
 		default:
-			err := fmt.Errorf("redis: unknown message: %T", msg)
+			err := fmt.Errorf("err: unknown message: %T", msg)
 			return nil, err
 		}
 	}
@@ -498,7 +498,7 @@ func (c *PubSub) Channel(opts ...ChannelOption) <-chan *Message {
 		c.msgCh.initMsgChan()
 	})
 	if c.msgCh == nil {
-		err := fmt.Errorf("redis: Channel can't be called after ChannelWithSubscriptions")
+		err := fmt.Errorf("err: Channel can't be called after ChannelWithSubscriptions")
 		panic(err)
 	}
 	return c.msgCh.msgCh
@@ -523,7 +523,7 @@ func (c *PubSub) ChannelWithSubscriptions(opts ...ChannelOption) <-chan interfac
 		c.allCh.initAllChan()
 	})
 	if c.allCh == nil {
-		err := fmt.Errorf("redis: ChannelWithSubscriptions can't be called after Channel")
+		err := fmt.Errorf("err: ChannelWithSubscriptions can't be called after Channel")
 		panic(err)
 	}
 	return c.allCh.allCh
@@ -664,11 +664,11 @@ func (c *channel) initMsgChan() {
 					}
 				case <-timer.C:
 					internal.Logger.Printf(
-						ctx, "redis: %s channel is full for %s (message is dropped)",
+						ctx, "err: %s channel is full for %s (message is dropped)",
 						c, c.chanSendTimeout)
 				}
 			default:
-				internal.Logger.Printf(ctx, "redis: unknown message type: %T", msg)
+				internal.Logger.Printf(ctx, "err: unknown message type: %T", msg)
 			}
 		}
 	}()
@@ -718,11 +718,11 @@ func (c *channel) initAllChan() {
 					}
 				case <-timer.C:
 					internal.Logger.Printf(
-						ctx, "redis: %s channel is full for %s (message is dropped)",
+						ctx, "err: %s channel is full for %s (message is dropped)",
 						c, c.chanSendTimeout)
 				}
 			default:
-				internal.Logger.Printf(ctx, "redis: unknown message type: %T", msg)
+				internal.Logger.Printf(ctx, "err: unknown message type: %T", msg)
 			}
 		}
 	}()

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -462,7 +462,7 @@ var _ = Describe("PubSub", func() {
 			_, err := pubsub.ReceiveMessage(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(SatisfyAny(
-				Equal("redis: client is closed"),
+				Equal("err: client is closed"),
 				ContainSubstring("use of closed network connection"),
 			))
 		}()

--- a/redis.go
+++ b/redis.go
@@ -624,7 +624,7 @@ func txPipelineReadQueued(rd *proto.Reader, statusCmd *StatusCmd, cmds []Cmder) 
 	}
 
 	if line[0] != proto.RespArray {
-		return fmt.Errorf("redis: expected '*', but got line %q", line)
+		return fmt.Errorf("err: expected '*', but got line %q", line)
 	}
 
 	return nil

--- a/redis_test.go
+++ b/redis_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Client", func() {
 	It("should close", func() {
 		Expect(client.Close()).NotTo(HaveOccurred())
 		err := client.Ping(ctx).Err()
-		Expect(err).To(MatchError("redis: client is closed"))
+		Expect(err).To(MatchError("err: client is closed"))
 	})
 
 	It("should close pubsub without closing the client", func() {
@@ -130,7 +130,7 @@ var _ = Describe("Client", func() {
 		Expect(pubsub.Close()).NotTo(HaveOccurred())
 
 		_, err := pubsub.Receive(ctx)
-		Expect(err).To(MatchError("redis: client is closed"))
+		Expect(err).To(MatchError("err: client is closed"))
 		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
 	})
 
@@ -152,7 +152,7 @@ var _ = Describe("Client", func() {
 		Expect(client.Close()).NotTo(HaveOccurred())
 
 		_, err := pubsub.Receive(ctx)
-		Expect(err).To(MatchError("redis: client is closed"))
+		Expect(err).To(MatchError("err: client is closed"))
 
 		Expect(pubsub.Close()).NotTo(HaveOccurred())
 	})

--- a/ring.go
+++ b/ring.go
@@ -20,7 +20,7 @@ import (
 	"github.com/dicedb/dicedb-go/internal/rand"
 )
 
-var errRingShardsDown = errors.New("redis: all ring shards are down")
+var errRingShardsDown = errors.New("err: all ring shards are down")
 
 //------------------------------------------------------------------------------
 
@@ -786,7 +786,7 @@ func (c *Ring) generalProcessPipeline(
 
 func (c *Ring) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	if len(keys) == 0 {
-		return fmt.Errorf("redis: Watch requires at least one key")
+		return fmt.Errorf("err: Watch requires at least one key")
 	}
 
 	var shards []*ringShard
@@ -803,13 +803,13 @@ func (c *Ring) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) er
 	}
 
 	if len(shards) == 0 {
-		return fmt.Errorf("redis: Watch requires at least one shard")
+		return fmt.Errorf("err: Watch requires at least one shard")
 	}
 
 	if len(shards) > 1 {
 		for _, shard := range shards[1:] {
 			if shard.Client != shards[0].Client {
-				err := fmt.Errorf("redis: Watch requires all keys to be in the same shard")
+				err := fmt.Errorf("err: Watch requires all keys to be in the same shard")
 				return err
 			}
 		}

--- a/ring_test.go
+++ b/ring_test.go
@@ -513,7 +513,7 @@ var _ = Describe("empty Redis Ring", func() {
 
 	It("returns an error", func() {
 		err := ring.Ping(ctx).Err()
-		Expect(err).To(MatchError("redis: all ring shards are down"))
+		Expect(err).To(MatchError("err: all ring shards are down"))
 	})
 
 	It("pipeline returns an error", func() {
@@ -521,7 +521,7 @@ var _ = Describe("empty Redis Ring", func() {
 			pipe.Ping(ctx)
 			return nil
 		})
-		Expect(err).To(MatchError("redis: all ring shards are down"))
+		Expect(err).To(MatchError("err: all ring shards are down"))
 	})
 })
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -571,7 +571,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 		return addr, nil
 	}
 
-	return "", errors.New("redis: all sentinels specified in configuration are unreachable")
+	return "", errors.New("err: all sentinels specified in configuration are unreachable")
 }
 
 func (c *sentinelFailover) replicaAddrs(ctx context.Context, useDisconnected bool) ([]string, error) {
@@ -644,7 +644,7 @@ func (c *sentinelFailover) replicaAddrs(ctx context.Context, useDisconnected boo
 	if sentinelReachable {
 		return []string{}, nil
 	}
-	return []string{}, errors.New("redis: all sentinels specified in configuration are unreachable")
+	return []string{}, errors.New("err: all sentinels specified in configuration are unreachable")
 }
 
 func (c *sentinelFailover) getMasterAddr(ctx context.Context, sentinel *SentinelClient) (string, error) {

--- a/tx.go
+++ b/tx.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TxFailedErr transaction redis failed.
-const TxFailedErr = proto.RedisError("redis: transaction failed")
+const TxFailedErr = proto.RedisError("err: transaction failed")
 
 // Tx implements Redis transactions as described in
 // http://redis.io/topics/transactions. It's NOT safe for concurrent use

--- a/watch_connection.go
+++ b/watch_connection.go
@@ -224,12 +224,12 @@ func (w *WatchConn) newWMessage(reply interface{}) (interface{}, error) {
 		return &Pong{Payload: reply}, nil
 	case []interface{}:
 		if len(reply) == 0 {
-			return nil, fmt.Errorf("redis: empty watchcommand message")
+			return nil, fmt.Errorf("err: empty watchcommand message")
 		}
 
 		kind, ok := reply[0].(string)
 		if !ok {
-			return nil, fmt.Errorf("redis: expected message type as string, got %T", reply[0])
+			return nil, fmt.Errorf("err: expected message type as string, got %T", reply[0])
 		}
 
 		if kind == "pong" {
@@ -238,26 +238,26 @@ func (w *WatchConn) newWMessage(reply interface{}) (interface{}, error) {
 			return w.processWatchResult(reply)
 		}
 	default:
-		return nil, fmt.Errorf("redis: unsupported watchcommand message type: %T", reply)
+		return nil, fmt.Errorf("err: unsupported watchcommand message type: %T", reply)
 	}
 }
 
 // processWatchResult parses a WATCHCOMMAND message from the server.
 func (w *WatchConn) processWatchResult(payload []interface{}) (*WatchResult, error) {
 	if len(payload) < 3 {
-		return nil, fmt.Errorf("redis: invalid watchcommand message format")
+		return nil, fmt.Errorf("err: invalid watchcommand message format")
 	}
 
 	// Ensure command is a string
 	command, ok := payload[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("redis: invalid command in watchcommand message, expected string, got %T", payload[0])
+		return nil, fmt.Errorf("err: invalid command in watchcommand message, expected string, got %T", payload[0])
 	}
 
 	// Ensure name is a string
 	fingerprint, ok := payload[1].(string)
 	if !ok {
-		return nil, fmt.Errorf("redis: invalid fingerprint in watchcommand message, expected string, got %T", payload[1])
+		return nil, fmt.Errorf("err: invalid fingerprint in watchcommand message, expected string, got %T", payload[1])
 	}
 
 	data := payload[2]
@@ -270,12 +270,12 @@ func (w *WatchConn) processWatchResult(payload []interface{}) (*WatchResult, err
 		}
 		typedData, ok = data.(string)
 		if !ok {
-			return nil, fmt.Errorf("redis: invalid data in GET.WATCH message, expected string, got %T", payload[2])
+			return nil, fmt.Errorf("err: invalid data in GET.WATCH message, expected string, got %T", payload[2])
 		}
 	case "ZRANGE.WATCH", "ZRANGE":
 		typedData, ok = parseZRangeResult(data)
 		if !ok {
-			return nil, fmt.Errorf("redis: invalid data in ZRANGE.WATCH message, expected []Z, got %T", payload[2])
+			return nil, fmt.Errorf("err: invalid data in ZRANGE.WATCH message, expected []Z, got %T", payload[2])
 		}
 	default:
 		typedData = data
@@ -357,7 +357,7 @@ func (w *WatchConn) ReceiveWMessage(ctx context.Context) (*WatchResult, error) {
 		case *WatchResult:
 			return msg, nil
 		default:
-			return nil, fmt.Errorf("redis: unknown message type: %T", msg)
+			return nil, fmt.Errorf("err: unknown message type: %T", msg)
 		}
 	}
 }
@@ -382,7 +382,7 @@ func (w *WatchConn) Channel(opts ...WChannelOption) <-chan *WatchResult {
 		w.msgCh.initMsgChan()
 	})
 	if w.msgCh == nil {
-		err := fmt.Errorf("redis: Channel can't be called after ChannelWithSubscriptions")
+		err := fmt.Errorf("err: Channel can't be called after ChannelWithSubscriptions")
 		panic(err)
 	}
 	return w.msgCh.msgCh
@@ -542,11 +542,11 @@ func (c *wChannel) initMsgChan() {
 					}
 				case <-timer.C:
 					internal.Logger.Printf(
-						ctx, "redis: %s channel is full for %s (message is dropped)",
+						ctx, "err: %s channel is full for %s (message is dropped)",
 						c.watchCmd, c.chanSendTimeout)
 				}
 			default:
-				internal.Logger.Printf(ctx, "redis: unknown message type: %T", msg)
+				internal.Logger.Printf(ctx, "err: unknown message type: %T", msg)
 			}
 		}
 	}()


### PR DESCRIPTION
This PR just removes all `redis: ` from the start of the error messages, and uses `err: ` instead.