### PR TITLE
fix: Improve watch command handling after closure

### DIFF
--- a/client_wire.go
+++ b/client_wire.go
@@ -17,7 +17,8 @@ type ClientWire struct {
 }
 
 func NewClientWire(maxMsgSize int, host string, port int) (*ClientWire, *wire.WireError) {
-	addr := fmt.Sprintf("%s:%d", host, port)
+	// Use net.JoinHostPort to properly handle both IPv4 and IPv6 addresses
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
 	if err != nil {
 		return nil, &wire.WireError{Kind: wire.NotEstablished, Cause: err}
@@ -42,4 +43,8 @@ func (cw *ClientWire) Receive() (*wire.Result, *wire.WireError) {
 
 func (cw *ClientWire) Close() {
 	cw.ProtobufTCPWire.Close()
+}
+
+func (cw *ClientWire) IsClosed() bool {
+	return cw.ProtobufTCPWire.IsClosed()
 }

--- a/internal/protobuf_wire.go
+++ b/internal/protobuf_wire.go
@@ -4,8 +4,9 @@
 package internal
 
 import (
-	"github.com/dicedb/dicedb-go/wire"
 	"net"
+
+	"github.com/dicedb/dicedb-go/wire"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -47,4 +48,8 @@ func (w *ProtobufTCPWire) Receive(dst proto.Message) *wire.WireError {
 
 func (w *ProtobufTCPWire) Close() {
 	w.tcpWire.Close()
+}
+
+func (w *ProtobufTCPWire) IsClosed() bool {
+	return w.tcpWire.IsClosed()
 }

--- a/internal/wire.go
+++ b/internal/wire.go
@@ -6,4 +6,5 @@ type Wire interface {
 	Send([]byte) *wire.WireError
 	Receive() ([]byte, *wire.WireError)
 	Close()
+	IsClosed() bool
 }


### PR DESCRIPTION
This update enables handling multiple watch commands for the same client after closing a previous watch connection.
- Added IsClosed() method to all wire interfaces for connection state checks
- Fixed watch connection handling to properly terminate watch loops
- Added context support to TCPWire for graceful read interruption
- Implemented CloseWatch() to properly close watch connections
- Fixed IPv6 address handling with net.JoinHostPort
- Improved error messages and code organization